### PR TITLE
Keep the incoming headers and send to backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.wso2.apim.demo.kerberos</groupId>
     <artifactId>org.wso2.apim.kerberos.handler</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>bundle</packaging>
 
     <name>org.wso2.apim.kerberos.handler</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.wso2.apim.demo.kerberos</groupId>
     <artifactId>org.wso2.apim.kerberos.handler</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.0</version>
     <packaging>bundle</packaging>
 
     <name>org.wso2.apim.kerberos.handler</name>

--- a/src/main/java/org/wso2/apim/kerberos/handler/utils/KerberosUtils.java
+++ b/src/main/java/org/wso2/apim/kerberos/handler/utils/KerberosUtils.java
@@ -61,11 +61,7 @@ public class KerberosUtils {
                                         byte[] serviceTicket) throws UnsupportedEncodingException {
 
         org.apache.axis2.context.MessageContext msgCtx = synCtx.getAxis2MessageContext();
-        Map<String, Object> headerProp = new HashMap<>();
-        headerProp.put(HttpHeaders.AUTHORIZATION, KerberosConstants.NEGOTIATE + " " +
-                java.util.Base64.getEncoder().encodeToString(serviceTicket));
-        msgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headerProp);
-
+        
         Map<String, String> headers = (Map<String, String>) msgCtx.getProperty(
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         ConcurrentHashMap<String, Object> headerProperties = new ConcurrentHashMap<>();


### PR DESCRIPTION
After adding this handler and making a request to the APIM with additional headers, all the headers are dropped at the API GW. Reason was creating a new header map. 